### PR TITLE
Update cp arguments for node_modules copy

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -21,7 +21,7 @@ fi
 # TODO: make this an incremental update so that upgrades are handled
 if [ ! -d "/data/node_modules" ]; then
     mkdir -p /data/node_modules
-    cp -ar /opt/strider/node_modules.cache/* /data/node_modules/
+    cp -r --preserve=mode,timestamps,links,xattr /opt/strider/node_modules.cache/* /data/node_modules/
 fi
 
 # Create admin user if variables defined


### PR DESCRIPTION
Under some circumstances cp throws errors like "cp: failed to preserve
ownership for..." normally when the data volume is on a NFS mount. This also
causes cp to exit non-zero and the docker container exits. This fix stops cp
from trying to preserving file ownership.
