### PR TITLE
Add DB_URI to strider user bashrc

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -15,6 +15,7 @@ set -e
 # Create a DB_URI from linked container variables above
 if [ -z "$DB_URI" ]; then
     export DB_URI="mongodb://${MONGO_PORT_27017_TCP_ADDR-localhost}:${MONGO_PORT_27017_TCP_PORT-27017}/strider"
+    echo 'export DB_URI="mongodb://${MONGO_PORT_27017_TCP_ADDR-localhost}:${MONGO_PORT_27017_TCP_PORT-27017}/strider"' > $HOME/.bashrc
 fi
 
 # Update npm cache if no modules exist


### PR DESCRIPTION
When using docker exec to enter a container the DB_URI is not always set.
entry.sh will create a .bashrc when DB_URI is not set when creating the
container. This allows the admin to `docker exec -i strider_container strider
addUser`
