### PR TITLE
[Fix] run docker-compose up twice cause duplicate user error

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -62,7 +62,7 @@ fi
 # Create admin user if variables defined
 if [ ! -z "$STRIDER_ADMIN_EMAIL" -a ! -z "$STRIDER_ADMIN_PASSWORD" ]; then
     echo "$(basename $0) >> Running addUser"
-    strider addUser --email $STRIDER_ADMIN_EMAIL --password $STRIDER_ADMIN_PASSWORD --admin true
+    strider addUser --email $STRIDER_ADMIN_EMAIL --password $STRIDER_ADMIN_PASSWORD --force --admin true
     echo "$(basename $0) >> Created Admin User: $STRIDER_ADMIN_EMAIL, Password: $STRIDER_ADMIN_PASSWORD"
 fi
 


### PR DESCRIPTION
When mongo volume is exposed to the host.

```
strider_1 | /data/node_modules/strider-cli/create-user.js:64
strider_1 |     rl.question('User already exists, overwrite? (y/n) [n]: ', function (overw
strider_1 |       ^
strider_1 | TypeError: Cannot read property 'question' of undefined
strider_1 |     at overwrite (/data/node_modules/strider-cli/create-user.js:64:7)
strider_1 |     at Promise.<anonymous> (/data/node_modules/strider-cli/create-user.js:14:9)
strider_1 |     at Promise.<anonymous> (/data/node_modules/mongoose/node_modules/mpromise/lib/promise.js:177:8)
strider_1 |     at Promise.emit (events.js:107:17)
strider_1 |     at Promise.emit (/data/node_modules/mongoose/node_modules/mpromise/lib/promise.js:84:38)
strider_1 |     at Promise.fulfill (/data/node_modules/mongoose/node_modules/mpromise/lib/promise.js:97:20)
strider_1 |     at /data/node_modules/mongoose/lib/query.js:1058:26
strider_1 |     at model.Document.init (/data/node_modules/mongoose/lib/document.js:254:11)
strider_1 |     at completeMany (/data/node_modules/mongoose/lib/query.js:1056:12)
strider_1 |     at Immediate.cb (/data/node_modules/mongoose/lib/query.js:1022:11)
strider_1 |     at Immediate._onImmediate (/data/node_modules/mongoose/node_modules/mquery/lib/utils.js:137:16)
strider_1 |     at processImmediate [as _immediateCallback] (timers.js:367:17)
```
